### PR TITLE
Load _sidebar.md explicitely

### DIFF
--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -6,7 +6,7 @@
   <title>Laravel-admin</title>
   <script>
       window.$docsify = {
-          loadSidebar: true,
+          loadSidebar: '_sidebar.md',
           subMaxLevel: 2,
           homepage: 'en/README.md',
           name: 'Laravel-admin',


### PR DESCRIPTION
In chromium (at least) it currently tries to load `true.md`.

This PR makes `docify` explicitely load `_sidebar.md`.

Thanks for this great package !